### PR TITLE
initial V13 compatibility 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.5.0] - 2025-06-16
+- Updated module for Foundry V13. 
+
+## [1.4.5] - 2024-08-20
+- Compatibility for Foundry v12.
+
+## [1.4.4] - 2023-11-07
+- Fixed an issue where pointer/mouse object could not be found.
+
 ## [1.2.0] - 2022-06-05 
 ### Added
 - New "Toggle Grid" button for quickly showing the current grid without having to go into the scene configuration.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Latest Version](https://img.shields.io/github/v/release/jbhaywood/scaleGrid)
-![Foundry Version](https://img.shields.io/endpoint?url=https%3A%2F%2Ffoundryshields.com%2Fversion%3Fstyle%3Dflat%26url%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fjbhaywood%2FscaleGrid%2Fmaster%2Fmodule.json)
+![Foundry Version](https://img.shields.io/endpoint?url=https%3A%2F%2Ffoundryshields.com%2Fversion%3Fstyle%3Dflat%26url%3Dhttps%3A%2F%2Fraw.githubusercontent.com%2Fatomdmac%2FscaleGrid%2Fmaster%2Fmodule.json)
 ![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2FscaleGrid&colorB=blueviolet)
 ![GitHub](https://img.shields.io/github/license/jbhaywood/scaleGrid)
 

--- a/module.json
+++ b/module.json
@@ -2,10 +2,10 @@
 	"id": "scaleGrid",
 	"title": "Grid Scaler",
 	"description": "A set of tools to quickly match the scene grid to your map's grid. Works with both squares and hexes.",
-	"version": "1.4.5",
+	"version": "1.5.0",
 	"compatibility": {
-		"minimum": 10,
-		"verified": "12"
+		"minimum": 13,
+		"verified": "13"
 	},
 	"authors": [
 		{
@@ -30,5 +30,5 @@
 	],
 	"url": "https://github.com/atomdmac/scaleGrid/",
 	"manifest": "https://raw.githubusercontent.com/atomdmac/scaleGrid/master/module.json",
-	"download": "https://github.com/atomdmac/scaleGrid/archive/refs/tags/v1.4.5.zip"
+	"download": "https://github.com/atomdmac/scaleGrid/archive/refs/tags/v1.5.0.zip"
 }

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -146,10 +146,9 @@ class ScaleGridLayer extends CanvasLayer {
           order: 8,
           title: "Toggle the grid display temporarily",
           toggle: true,
-          onChange: (isActive) => { 
-            console.log("ToggleGridTool onChange called, active:", isActive); 
-            gridScaler.toggleGrid(); 
-          } 
+          onChange: (_, isActive) => { 
+            gridScaler.toggleGrid(isActive); 
+          }
         },
         ResetGridTool: {
           icon: "fas fa-undo",
@@ -960,49 +959,50 @@ class ScaleGridLayer extends CanvasLayer {
   // to be fully transparent or just really light. In those cases, it's a pain to manually configure 
   // the settings to make it easier to see while you line up the Foundry grid. This lets you toggle 
   // an easy to see grid temporarily to make the job easier.
-  toggleGrid() {
+  toggleGrid(isActive) {
     const curSceneId = canvas.scene.id;
 
-    if (!gridScaler.cavasGridTempSettings[curSceneId]) {
-      gridScaler.saveGridSettings(curSceneId);
-      gridScaler.makeGridVisible();
+    if (isActive) {
+      if (!gridScaler.cavasGridTempSettings[curSceneId]) {
+        gridScaler.saveGridSettings(curSceneId);
+        gridScaler.makeGridVisible();
+      }
     } else {
-      gridScaler.resetGridSettings(curSceneId);
+      if (gridScaler.cavasGridTempSettings[curSceneId]) {
+        gridScaler.resetGridSettings(curSceneId);
+      }
     }
   }
 
   // Turn the grid red and make it fully opaque and visible.
-  makeGridVisible() {
-    canvas.grid.visible = true;
-
-    gridUtils.refreshGrid({
-      grid: true,
-      alpha: 1,
-      color: "#FF0000"
+  async makeGridVisible() {
+    await canvas.scene.update({
+      "grid.alpha": 1,
+      "grid.color": "#FF0000"
     });
   }
 
   // Save the color and alpha of the current scene's grid.
   // We'll use this to reset it when the preview is toggled off. 
   saveGridSettings(sceneId) {
-    gridScaler.cavasGridTempSettings[sceneId] = {
-      visible: GridLayer.instance.visible,
-      alpha: GridLayer.instance.alpha,
-      color: GridLayer.instance.color
+    const scene = canvas.scene;
+    
+    const settings = {
+      alpha: scene.grid.alpha,
+      color: scene.grid.color
     };
+
+    gridScaler.cavasGridTempSettings[sceneId] = settings;
   }
 
   // Set the grid's color and alpha back to their original settings.
-  resetGridSettings(sceneId) {
+  async resetGridSettings(sceneId) {
     const settings = gridScaler.cavasGridTempSettings[sceneId];
 
     if (settings) {
-      canvas.grid.visible = settings.visible;
-
-      gridUtils.refreshGrid({
-        grid: true,
-        alpha: settings.alpha,
-        color: settings.color
+      await canvas.scene.update({
+        "grid.alpha": settings.alpha,
+        "grid.color": settings.color
       });
 
       gridScaler.cavasGridTempSettings[sceneId] = null;

--- a/scripts/gridScale.js
+++ b/scripts/gridScale.js
@@ -85,71 +85,93 @@ class ScaleGridLayer extends CanvasLayer {
   // <================== Button Setup ====================>
   setButtons() {
     gridScaler.newButtons = {
-      activeTool: "GridScaler",
       name: "grid",
       icon: "fas fa-border-all",
-      layer: "controls",
+      order: 11,
       title: "Grid Controls",
-      tools: [
-        {
+      visible: true,
+      onChange: () => {},
+      tools: {
+        DrawGridTool: {
           icon: "fas fa-square",
           name: "DrawGridTool",
+          order: 2,
           title: "Set grid by drawing either a square or hexagon",
           button: true,
-          onClick: gridScaler.setupDrawGrid
+          onChange: gridScaler.setupDrawGrid
         },
-        {
+        Draw3x3Tool: {
           icon: "fas fa-th",
           name: "Draw3x3Tool",
+          order: 2,
           title: "Set grid by drawing a 3x3 box",
           button: true,
-          onClick: gridScaler.setupDraw3X3
+          onChange: gridScaler.setupDraw3X3
         },
-        {
+        AdjustXTool: {
           icon: "fas fa-ruler-horizontal",
           name: "AdjustXTool",
+          order: 4,
           title: "Set the X position of the grid",
           button: true,
-          onClick: gridScaler.setupAdjustX
+          onChange: gridScaler.setupAdjustX
         },
-        {
+        AdjustYTool: {
           icon: "fas fa-ruler-vertical",
           name: "AdjustYTool",
+          order: 5,
           title: "Set the Y position of the grid",
           button: true,
-          onClick: gridScaler.setupAdjustY
+          onChange: gridScaler.setupAdjustY
         },
-        {
+        MoveGridTool: {
           icon: "fas fa-object-group",
           name: "MoveGridTool",
+          order: 6,
           title: "Move and scale the grid",
           button: true,
-          onClick: gridScaler.openGridMoveDialog
+          onChange: gridScaler.openGridMoveDialog
         },
-        {
+        ManualGridSizeTool: {
           icon: 'fas fa-pen-square',
           name: "ManualGridSizeTool",
+          order: 7,
           title: "Set the grid by number of squares or hexes",
           button: true,
-          onClick: gridScaler.openGridSizeDialog
+          onChange: gridScaler.openGridSizeDialog
         },
-        {
+        ToggleGridTool: {
           icon: 'fas fa-border-none',
           name: "ToggleGridTool",
+          order: 8,
           title: "Toggle the grid display temporarily",
           toggle: true,
-          onClick: gridScaler.toggleGrid
+          onChange: (isActive) => { 
+            console.log("ToggleGridTool onChange called, active:", isActive); 
+            gridScaler.toggleGrid(); 
+          } 
         },
-        {
+        ResetGridTool: {
           icon: "fas fa-undo",
           name: "ResetGridTool",
+          order: 9,
           title: "Reset the grid",
           button: true,
-          onClick: e => {
-            this.resetDialog(e);
+          onChange: (e) => {
+            gridScaler.resetDialog(e);
           }
+        },
+        dummyTool: {
+          // remove select tool when foundry issue #12966 is resolved
+          icon: "fa-solid fa-expand",
+          name: "dummyTool",
+          title: "functionless default tool", 
+          order: 10,
+          visible: false, 
+          onChange: () => {}
         }
-      ]
+      },
+      activeTool: "dummyTool"  // set to "" when foundry issue #12966 is resolved- currently need to specify a dummy Tool as active Tool.
     }
   }
 
@@ -993,7 +1015,7 @@ class ScaleGridLayer extends CanvasLayer {
   initialize() {
     Hooks.on('getSceneControlButtons', controls => {
       if (game.user.isGM) {
-        controls.push(gridScaler.newButtons);
+        controls.grid = gridScaler.newButtons;
       }
     });
 

--- a/scripts/gridUtils.js
+++ b/scripts/gridUtils.js
@@ -147,12 +147,24 @@ export class gridUtils {
 
     // Update the grid layer
     if (grid) {
-      canvas.interface.grid.mesh.initialize({
-        dimensions: d,
-        size: d.size,
-        color: Color.fromString(color.toString().replace("#", "0x")),
-        alpha: alpha
-      })
+      // V13 approach
+      if (canvas.interface?.grid?.draw) {
+        canvas.interface.grid.draw({
+          dimensions: d,
+          size: d.size,
+          color: color,
+          alpha: alpha
+        });
+      } 
+      // Fallback to V12
+      else {
+        canvas.interface.grid.mesh.initialize({
+          dimensions: d,
+          size: d.size,
+          color: Color.fromString(color.toString().replace("#", "0x")),
+          alpha: alpha
+        });
+      }
 
       canvas.stage.hitArea = d.rect;
     }


### PR DESCRIPTION
This is an initial V13 release. Let me know if there are questions or concerns. Thanks! 

## Known Issues
1. Currently when a button is used, the scale grid control group is deselected meaning if you want to use multiple scale grid buttons in a row, you need to click back on the scale grid group in between each button. I tried debugging this without much success and believe it is part of a larger architectural issue or with the `canvas.stage.addListener()`. Unfortunately I didn't have time or expertise to resolve this. 
2. There is a [minor bug in foundry](https://github.com/foundryvtt/foundryvtt/issues/12966) that requires an `activeTool` to be selected when the scale grid control group is selected. To resolve this I created a dummyTool that is hidden from the user. This allows the module to work but it does throw a warning in console each time the scale grid group is selected, because [hidden tools currently do not have functional handlers.](https://github.com/foundryvtt/foundryvtt/issues/13037). Once ticket #12966 is completed, the dummy tool can be removed and `activeTool` set to `""`. This has been documented in the comments in gridScale.js

## To Release
I only tested on V13 and due to some of the changes I'm unsure if they will be backwards compatible. The module.json minimum version has been bumped to 13 accordingly.  
1. In FoundryVTT navigate to your account -> Packages -> update the last release module.json location to `https://raw.githubusercontent.com/atomdmac/scaleGrid/v1.4.5/module.json`. Since the module.json already directs to the 1.4.5 download this should ensure that older versions of foundry will still have easy access to V10-V12.
2. Create new tag for `v1.5.0` and release on foundry (now or after someone can resolve the first known issue). Specify minimum V13, Verified V13. 


Closes #8 